### PR TITLE
Update yamllint configuration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,5 @@
 name: Check
-on: # yamllint disable-line rule:truthy
+on:
   pull_request: ~
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Publish
-on: # yamllint disable-line rule:truthy
+on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: # yamllint disable-line rule:truthy
+on:
   pull_request:
     paths:
       - .github/workflows/test.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -77,4 +77,4 @@ rules:
     allowed-values:
       - "true"
       - "false"
-    check-keys: true
+    check-keys: false


### PR DESCRIPTION
### Summary

Update the configuration of yamllint's `truthy` rule to NOT check keys for truthy values. Enforcing this rule in this way was incorrect, keys are not values and thus cannot be truthy either. Moreover, the key "on" should never be disallowed.
