### PR TITLE
Add and use actionlint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,7 @@ jobs:
         uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Add plugins
         run: |
+          asdf plugin add actionlint https://github.com/crazy-matt/asdf-actionlint.git
           asdf plugin add shellcheck https://github.com/luizm/asdf-shellcheck.git
           asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
@@ -67,6 +68,7 @@ jobs:
         uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Add plugins
         run: |
+          asdf plugin add actionlint https://github.com/crazy-matt/asdf-actionlint.git
           asdf plugin add shellcheck https://github.com/luizm/asdf-shellcheck.git
           asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,23 @@ on:
 permissions: read-all
 
 jobs:
+  ci:
+    name: CI Workflows
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+          asdf plugin add actionlint https://github.com/crazy-matt/asdf-actionlint.git
+          asdf plugin add shellcheck https://github.com/luizm/asdf-shellcheck.git
+          asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Lint
+        run: make lint-ci
   markdown:
     name: MarkDown
     runs-on: ubuntu-22.04

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 # Check out asdf at: https://asdf-vm.com/
 
+actionlint 1.6.23
 shellcheck 0.9.0
 yamllint 1.29.0

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ help: ## Show this help message
 		printf "  \033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
+lint-ci: $(ASDF) ## Lint CI workflows
+	@actionlint
+
 lint-md: ## Lint .md files
 	@markdownlint \
 		--config .markdownlint.yml \
@@ -46,4 +49,4 @@ test-run: ## Run the action locally
 		./validate.sh \
 	)
 
-.PHONY: clean default help lint-md lint-sh lint-yml release test-run
+.PHONY: clean default help lint-ci lint-md lint-sh lint-yml release test-run

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Show this help message
 		printf "  \033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
-lint-ci: $(ASDF) ## Lint CI workflows
+lint-ci: ## Lint CI workflows
 	@actionlint
 
 lint-md: ## Lint .md files


### PR DESCRIPTION
## Summary

Add and use [actionlint](https://github.com/rhysd/actionlint) to lint the CI workflow files for problems.