### PR TITLE
Improve Action output for non-`200` results

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -10,9 +10,24 @@ RESULT=$(
 
 echo "status-code=${RESULT}" >>"${GITHUB_OUTPUT}"
 
-if [ "${RESULT}" != "200" ]; then
-	echo "Codecov configuration is invalid (got ${RESULT})"
+if [ "${RESULT}" == "200" ]; then
+	echo "Codecov configuration is valid."
+	exit 0
+elif [ "${RESULT}" -ge "400" ] && [ "${RESULT}" -lt "500" ]; then
+	echo "Codecov configuration is invalid (got ${RESULT})."
+	echo ''
+	echo "Update the Codecov configuration file at ${FILE} to make it valid."
+	exit 1
+elif [ "${RESULT}" -ge "500" ]; then
+	echo "Codecov configuration could not be validated (got ${RESULT})."
+	echo ''
+	echo "You can try to rerun this job after a short delay and it should pass then."
+	echo "If the exact response code ${RESULT} persists, verify Codecov does not have an outage."
 	exit 1
 else
-	echo "Codecov configuration is valid"
+	echo "Codecov configuration validation state unknown (got ${RESULT})."
+	echo ''
+	echo 'If this persists open an issue at:'
+	echo 'https://github.com/ericcornelissen/codecov-config-validator-action/issues/new'
+	exit 1
 fi


### PR DESCRIPTION
Closes #18

## Summary

Improve the output of the Action by adapting the output for non-`200` responses to be more granular. In particular, the primary goal is to avoid saying `500` errors indicate invalid configuration, and avoid making claims about validity in the event of an unexpected status code.

The text used here slightly deviates from the proposed text, this is just in an effort to improve clarity.