### PR TITLE
Update "Publish / GitHub Release" job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
         uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
         with:
           name: Release ${{ steps.version.outputs.result }}
+          body: Release ${{ steps.version.outputs.result }}
           tag: ${{ steps.version.outputs.result }}
           draft: false
           makeLatest: true


### PR DESCRIPTION
## Summary

Update the CI job that creates a GitHub Release to include an explicit `body` (release text) in order to avoid GitHub displaying the commit message of the commit associated with the tag that the release belongs to.