### PR TITLE
Document required network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ _See the [steps context] documentation for how to use output values._
 
 - `status-code`: The HTTP status code returned by the Codecov API.
 
-## Permissions
+## Security
+
+### Permissions
 
 This Action requires no [permissions].
+
+### Network
+
+This Action requires network access to the endpoint `codecov.io:443`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Extend the security topic of "Permissions" in the documentation with a section on the network access this Action requires to function.