### PR TITLE
Set up a nightly workflow to update tooling

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -1,0 +1,20 @@
+name: Tooling
+on:
+  schedule:
+    - cron: 0 5 * * *
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  tooling:
+    name: Update tooling
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To push a commit
+      pull-requests: write # To open a Pull Request
+    steps:
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action@064e8ec8eb90efcfa2e942d15b22ab7d889e85b1 # v0.1.0
+        with:
+          max: 1


### PR DESCRIPTION
Relates to #25

## Summary

Create a new GitHub Actions workflow that is run on a nightly schedule to create Pull Requests to update tools defined in the `.tool-versions` file using [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action).