### PR TITLE
Output the Codecov API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,6 @@ in this file.
 
 ## Changes
 
+- (2023-06-17) Include the Codecov API response in the Action logs.
 - (2023-04-21) Improve Action output for non-`200` results.
 - (2022-12-04) Basic validation of Codecov configuration files.

--- a/validate.sh
+++ b/validate.sh
@@ -16,7 +16,7 @@ echo '::group::Codecov API response'
 for t in "${RESPONSE_LINES[@]::${#RESPONSE_LINES[@]}-1}"; do
 	echo "${t}"
 done
-echo '::endgroup'
+echo '::endgroup::'
 
 if [ "${RESPONSE_CODE}" == "200" ]; then
 	echo "Codecov configuration is valid."


### PR DESCRIPTION
Closes #30 

## Summary

Update the Action logs to include the (raw) Codecov API response body. The response body is logged into a [log group](https://github.com/actions/toolkit/blob/a6bf8726aa7b78d4fc8111359cca5d538527b239/packages/core/src/core.ts#L301-L317) for readability.