### PR TITLE
Stop using markdownlint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,16 +26,6 @@ jobs:
         uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
       - name: Lint
         run: make lint-ci
-  markdown:
-    name: MarkDown
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Install markdownlint-cli
-        run: npm install --global markdownlint-cli
-      - name: Lint
-        run: make lint-md
   secrets:
     name: Secrets
     runs-on: ubuntu-22.04

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,0 @@
-# Check out markdownlint at: https://github.com/DavidAnson/markdownlint
-
-default: true

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,6 @@ help: ## Show this help message
 lint-ci: ## Lint CI workflows
 	@actionlint
 
-lint-md: ## Lint .md files
-	@markdownlint \
-		--config .markdownlint.yml \
-		--dot \
-		--ignore-path .gitignore \
-		.
-
 lint-sh: ## Lint .sh files
 	@shellcheck \
 		validate.sh


### PR DESCRIPTION
## Summary

Remove the use of markdownlint and corresponding Make command and continuous integration job.

The motivation for removing it is that it's installation is non-ideal (a global npm install) and not automated nor document. Also, the version is not recorded in any way.

I'd be in favor of re-adding it (or adding a similar tool) if the above concerns can be addressed.