### PR TITLE
Support locally running e2e tests

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,5 @@
+# Check out act at: https://github.com/nektos/act
+
+--platform ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
+--quiet
+--use-gitignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Run tests
+        if: ${{ !env.ACT }}
         run: make test
   e2e:
     name: End-to-end

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@
 # - asdf: https://asdf-vm.com/
 # - rtx: https://github.com/jdxcode/rtx
 
+act 0.2.49
 actionlint 1.6.25
 shellcheck 0.9.0
 shfmt 3.7.0

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ else
 	@git push origin "v$v"
 endif
 
-.PHONY: test test-run
+.PHONY: test test-e2e test-run
 test: ## Run the automated tests
 	@echo 'Testing valid config...'
 	@test/test_valid.sh
@@ -71,6 +71,9 @@ test: ## Run the automated tests
 	@echo ''
 	@echo 'Testing unexpected response...'
 	@test/test_unexpected.sh
+
+test-e2e: ## Run the end-to-end tests
+	@act --job e2e
 
 test-run: ## Run the action locally
 	@rm -f ${GITHUB_OUTPUT}


### PR DESCRIPTION
Relates to #52

## Summary

Add support for running the end-to-end (e2e) tests locally by using [act](https://github.com/nektos/act).