### PR TITLE
Revert removal of "An automated regression test" from the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,7 @@ Try to include as many of the following items as possible in a security report:
 - The latest affected version
 - The earliest affected version
 - A suggested patch
+- An automated regression test
 
 [cwe]: https://cwe.mitre.org/
 


### PR DESCRIPTION
Reverts #49
Relates to #52

## Summary

Now that the project has tests, the suggestion to include "An automated regression test" can be (re-)added to the security policy.