### PR TITLE
Bump the versions of other actions used in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A GitHub action to validate [Codecov] configuration files.
 ## Usage
 
 ```yml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: ericcornelissen/codecov-config-validator-action@v1
   with:
     # Provide a path to the location of the Codecov configuration file.
@@ -43,7 +43,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ericcornelissen/codecov-config-validator-action@v1
         with:
           file: .github/codecov.yml


### PR DESCRIPTION
## Summary

- Bump version of `actions/checkout` used in docs.
- No other external actions are present in the docs of this project.