### PR TITLE
Drop dev dependency on `act`

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,5 +1,0 @@
-# Check out act at: https://github.com/nektos/act
-
---platform ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
---quiet
---use-gitignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Run tests
-        if: ${{ !env.ACT }}
         run: make test
   e2e:
     name: End-to-end

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,6 @@
 # - asdf: https://asdf-vm.com/
 # - rtx: https://github.com/jdxcode/rtx
 
-act 0.2.49
 actionlint 1.6.25
 shellcheck 0.9.0
 shfmt 3.7.0

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,6 @@ test: ## Run the automated tests
 	@echo 'Testing unexpected response...'
 	@test/test_unexpected.sh
 
-test-e2e: ## Run the end-to-end tests
-	@act --job e2e
-
 test-run: ## Run the action locally
 	@rm -f ${GITHUB_OUTPUT}
 	@touch ${GITHUB_OUTPUT}


### PR DESCRIPTION
Relates to #53
Supersedes #61

## Summary

Using `act` has not proven to be particularly useful while adding a maintenance burden in terms of keeping it up-to-date. Hence, this removes the `act` configuration from the project. Of course, it's still possible for contributors to use `act` if they so choose.