### PR TITLE
Use token to create tooling update Pull Requests

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -14,8 +14,15 @@ jobs:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
     steps:
+      - name: Create token to create Pull Request
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        id: automation-token
+        with:
+          app_id: ${{ secrets.AUTOMATION_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@80dab8d99cefefdcfcc6ad4adbb6bc7a07c39e7f # v0.3.7
         with:
           labels: dependencies
           max: 1
+          token: ${{ steps.automation-token.outputs.token }}


### PR DESCRIPTION
Relates to #32

## Summary

Add the use of `tibdex/github-app-token` to the tooling job to generate a token that can be used to create a Pull Request for which CI jobs are run. This is an improvement over the status quo as it will remove the need to either 1) create a manual commit to trigger the CI or 2) ignore the absence of CI checks.