### PR TITLE
Run tests on multiple runner images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,14 @@ permissions: read-all
 
 jobs:
   unit:
-    name: Unit
-    runs-on: ubuntu-22.04
+    name: Unit (${{ matrix.runs-on }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - ubuntu-20.04
+          - ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ _See the [steps context] documentation for how to use output values._
 
 - `status-code`: The HTTP status code returned by the Codecov API.
 
+## Runners
+
+This action is tested on the official [`ubuntu-20.04`] and [`ubuntu-22.04`]
+runner images. It is recommended to use one of these images when using this
+action.
+
 ## Security
 
 ### Permissions
@@ -84,3 +90,5 @@ how to improve the documentation.
 [open an issue]: https://github.com/ericcornelissen/codecov-config-validator-action/issues/new?labels=documentation
 [permissions]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 [steps context]: https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
+[`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md


### PR DESCRIPTION
Relates to #52

## Summary

Update the Test continuous integration workflow to run unit tests on all currently available Linux runner images to ensure the Actions would work on each of them. Correspondingly, add sections to the various docs that these runner images are tested and recommended.