### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   ci:
     name: CI Workflows
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -28,7 +28,7 @@ jobs:
         run: make lint-ci
   secrets:
     name: Secrets
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -43,7 +43,7 @@ jobs:
           GITLEAKS_ENABLE_SUMMARY: false
   shell:
     name: Shell scripts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -63,7 +63,7 @@ jobs:
         run: make format-check
   types:
     name: Types
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -71,7 +71,7 @@ jobs:
         uses: krzema12/github-actions-typing@c1af3441a3e80d0010be36aa0874f157a15f6a7f # v1.0.2
   yaml:
     name: YAML
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   github:
     name: GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To create a GitHub Release
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-20.04
-          - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -38,7 +38,7 @@ jobs:
         run: make test
   e2e:
     name: End-to-end
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - unit
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   tooling:
     name: Update tooling
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ _See the [steps context] documentation for how to use output values._
 
 ## Runners
 
-This action is tested on the official [`ubuntu-20.04`] and [`ubuntu-22.04`]
-runner images. It is recommended to use one of these images when using this
-action.
+This action is tested on the official [`ubuntu-20.04`], [`ubuntu-22.04`], and
+[`ubuntu-24.04`] runner images. It is recommended to use one of these images
+when using this action.
 
 ## Security
 
@@ -92,3 +92,4 @@ how to improve the documentation.
 [steps context]: https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
 [`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
 [`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+[`ubuntu-24.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. **NOTE:** As of writing this runner is still in beta, so this should not be merged.